### PR TITLE
feat!: shadcn UI migration (major release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,18 @@
   },
   "release": {
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/git",


### PR DESCRIPTION
Configure semantic-release to use the conventionalcommits preset so the `!` breaking-change shorthand triggers major bumps going forward.

BREAKING CHANGE: UI fully migrated from Bootstrap to shadcn/Tailwind.